### PR TITLE
DiContainerExtensions for InitializeTicks and ReleaseTicks

### DIFF
--- a/Runtime/Utility/Initializable/InitializableUtility.cs
+++ b/Runtime/Utility/Initializable/InitializableUtility.cs
@@ -43,51 +43,5 @@ namespace TapEmpire.Services
             }
             return UniTask.WaitUntil(() => initializables.All(initializable => initializable.Initialized), cancellationToken: cancellationToken);
         }
-
-        public static void InitializeTicks<T>(T[] initializables, DiContainer diContainer) where T : IInitializable
-        {
-            var tickableManager = diContainer.Resolve<TickableManager>();
-
-            foreach (var system in initializables)
-            {
-                var systemType = system.GetType();
-
-                if (typeof(ITickable).IsAssignableFrom(systemType))
-                {
-                    tickableManager.Add(system as ITickable);
-                }
-                if (typeof(IFixedTickable).IsAssignableFrom(systemType))
-                {
-                    tickableManager.AddFixed(system as IFixedTickable);
-                }
-                if (typeof(ILateTickable).IsAssignableFrom(systemType))
-                {
-                    tickableManager.AddLate(system as ILateTickable);
-                }
-            }
-        }
-
-        public static void ReleaseTicks<T>(T[] initializables, DiContainer diContainer) where T : IInitializable
-        {
-            var tickableManager = diContainer.Resolve<TickableManager>();
-
-            foreach (var system in initializables)
-            {
-                var systemType = system.GetType();
-
-                if (typeof(ITickable).IsAssignableFrom(systemType))
-                {
-                    tickableManager.Remove(system as ITickable);
-                }
-                if (typeof(IFixedTickable).IsAssignableFrom(systemType))
-                {
-                    tickableManager.RemoveFixed(system as IFixedTickable);
-                }
-                if (typeof(ILateTickable).IsAssignableFrom(systemType))
-                {
-                    tickableManager.RemoveLate(system as ILateTickable);
-                }
-            }
-        }
     }
 }

--- a/Runtime/Utility/Zenject.meta
+++ b/Runtime/Utility/Zenject.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: dbb1fa65e0ea44acbfba99f698f56bf3
+timeCreated: 1727148484

--- a/Runtime/Utility/Zenject/DiContainerExtensions.cs
+++ b/Runtime/Utility/Zenject/DiContainerExtensions.cs
@@ -1,0 +1,48 @@
+﻿using Zenject;
+
+namespace TapEmpire.Utility
+{
+    public static class DiContainerExtensions
+    {
+        public static void InitializeTicks<T>(this DiContainer diContainer, params T[] targets) where T : class
+        {
+            var tickableManager = diContainer.Resolve<TickableManager>();
+            foreach (var target in targets)
+            {
+                if (target is ITickable tickable)
+                {
+                    tickableManager.Add(tickable);
+                }
+                if (target is IFixedTickable fixedTickable)
+                {
+                    tickableManager.AddFixed(fixedTickable);
+                }
+                if (target is ILateTickable lateTickable)
+                {
+                    tickableManager.AddLate(lateTickable);
+                }
+            }
+        }
+        
+        public static void ReleaseTicks<T>(this DiContainer diContainer, params T[] targets) where T : class
+        {
+            var tickableManager = diContainer.Resolve<TickableManager>();
+
+            foreach (var target in targets)
+            {
+                if (target is ITickable tickable)
+                {
+                    tickableManager.Add(tickable);
+                }
+                if (target is IFixedTickable fixedTickable)
+                {
+                    tickableManager.AddFixed(fixedTickable);
+                }
+                if (target is ILateTickable lateTickable)
+                {
+                    tickableManager.AddLate(lateTickable);
+                }
+            }
+        }
+    }
+}

--- a/Runtime/Utility/Zenject/DiContainerExtensions.cs.meta
+++ b/Runtime/Utility/Zenject/DiContainerExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c8100dc4b817454e8d1acbf1de276544
+timeCreated: 1727148491


### PR DESCRIPTION
Перенес InitializeTicks логику в отдельный экстеншон, не только для Initializables нужна такая логика (для модулей применил). Если использовалось где-то в проектах, то нужно будет поменять точки вызова.
/+ убрал GetType, просто делаю is ITickable
![image](https://github.com/user-attachments/assets/23038f02-f4ce-4385-98be-ff18729ffcfa)
